### PR TITLE
Add canCode() to Workable

### DIFF
--- a/4-interface-segregation-principle.php
+++ b/4-interface-segregation-principle.php
@@ -3,6 +3,7 @@
 // Interface Segregation Principle Violation
 interface Workable
 {
+    public function canCode();
     public function code();
     public function test();
 }


### PR DESCRIPTION
Hello,

I'd like to thank you for your work, it helped me to better understand SOLID principles. But I noticed something in ISP example, a method not defined in Workable is called on a Workable instance (line 50).

This commit just adds the method to Workable.

Hope that helps.