### PR TITLE
Refactor and Implement Send Functionality in Mailer Classes with Usage Example

### DIFF
--- a/5-dependency-inversion-principle.php
+++ b/5-dependency-inversion-principle.php
@@ -21,22 +21,25 @@ interface Mailer
     public function send();
 }
 
+// Concrete implementation of Mailer using SMTP
 class SmtpMailer implements Mailer
 {
     public function send()
     {
-
+        echo 'send message from SMTP mailer';
     }
 }
 
+// Concrete implementation of Mailer using SendGrid
 class SendGridMailer implements Mailer
 {
     public function send()
     {
-
+        echo 'send message from SendGrid mailer';
     }
 }
 
+// High-level module that depends on the Mailer abstraction
 class SendWelcomeMessage
 {
     private $mailer;
@@ -45,4 +48,18 @@ class SendWelcomeMessage
     {
         $this->mailer = $mailer;
     }
+
+    public function sendWelcome()
+    {
+        $this->mailer->send();
+    }
 }
+
+// Usage example
+$smtpMailer = new SmtpMailer();
+$welcomeMessage = new SendWelcomeMessage($smtpMailer);
+$welcomeMessage->sendWelcome(); // Outputs: send message from SMTP mailer
+
+$sendGridMailer = new SendGridMailer();
+$welcomeMessage = new SendWelcomeMessage($sendGridMailer);
+$welcomeMessage->sendWelcome(); // Outputs: send message from SendGrid mailer


### PR DESCRIPTION
This update implements the send() method in both the SmtpMailer and SendGridMailer classes, providing output to demonstrate their functionality. Additionally, I added a sendWelcome() method to the SendWelcomeMessage class, which calls the send() method on the provided mailer instance.

A usage example is included to showcase how SendWelcomeMessage can work with different mailer implementations, adhering to the Dependency Inversion Principle (DIP). This enhances code clarity and illustrates how the mailers can be easily swapped.